### PR TITLE
feat: optimize lock waiting to use exact expiry time

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@actions/github": "^6.0.0",
     "@aws-sdk/client-s3": "^3.779.0",
     "@aws-sdk/lib-storage": "^3.777.0",
-    "ansi-styles": "^6.2.1",
+    "ansi-styles": "5.2.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/S3Lock.test.ts
+++ b/src/S3Lock.test.ts
@@ -1,0 +1,27 @@
+import { Duration } from "./duration";
+import { S3Lock } from "./S3Lock";
+import { S3LockExt } from "./S3LockExt";
+
+describe("S3Lock", () => {
+  describe("durationTillExpiry", () => {
+    test("returns the duration until the lock expires", () => {
+      const bucket = "test-bucket";
+      const name = "test-lock";
+      const expires = new Duration("1h");
+      const s3Lock = new S3Lock(bucket, name, expires);
+      
+      const now = new Date();
+      const expiryTime = new Date(now.getTime() + 30 * 60 * 1000); // 30 minutes from now
+      const ext = new S3LockExt();
+      ext.createdAt = now;
+      ext.expiresAt = expiryTime;
+      ext.uuid = "test-uuid";
+      
+      const key = `${name}.${ext.toString()}`;
+      const expectedDuration = Duration.until(expiryTime);
+      const result = s3Lock.durationTillExpiry(key);
+      
+      expect(result.seconds()).toBeCloseTo(expectedDuration.seconds(), 0); // within 5 seconds
+    });
+  });
+}); 

--- a/src/S3Lock.ts
+++ b/src/S3Lock.ts
@@ -116,8 +116,7 @@ export class S3Lock {
   }
 
   async waitDuration(key: string): Promise<Duration> {
-    const end = key.slice(this.prefix.length);
-    const { expiresAt } = S3LockExt.fromString(end);
+    const { expiresAt } = S3LockExt.fromKey(this.prefix, key);
     return Duration.until(expiresAt);
   }
 }

--- a/src/S3Lock.ts
+++ b/src/S3Lock.ts
@@ -115,7 +115,7 @@ export class S3Lock {
     );
   }
 
-  async waitDuration(key: string): Promise<Duration> {
+  durationTillExpiry(key: string): Duration {
     const { expiresAt } = S3LockExt.fromKey(this.prefix, key);
     return Duration.until(expiresAt);
   }

--- a/src/S3Lock.ts
+++ b/src/S3Lock.ts
@@ -114,4 +114,10 @@ export class S3Lock {
       }),
     );
   }
+
+  async waitDuration(key: string): Promise<Duration> {
+    const end = key.slice(this.prefix.length);
+    const { expiresAt } = S3LockExt.fromString(end);
+    return Duration.until(expiresAt);
+  }
 }

--- a/src/S3LockExt.test.ts
+++ b/src/S3LockExt.test.ts
@@ -67,4 +67,46 @@ describe("S3LockExt", () => {
 
     expect(exts.sort()).toEqual([ext1, ext2, ext3, ext4]);
   });
+
+  describe("fromKey", () => {
+    test("extracts extension from a key with prefix", () => {
+      const createdAt = new Date("2023-01-01T12:00:00Z");
+      const expiresAt = new Date("2023-01-01T13:00:00Z");
+      const uuid = "test-uuid";
+      
+      const ext = new S3LockExt();
+      ext.createdAt = createdAt;
+      ext.expiresAt = expiresAt;
+      ext.uuid = uuid;
+      
+      const prefix = "test/prefix/";
+      const key = `${prefix}${ext.toString()}`;
+      
+      const result = S3LockExt.fromKey(prefix, key);
+      
+      expect(result.uuid).toEqual(uuid);
+      expect(result.createdAt.getTime()).toEqual(createdAt.getTime());
+      expect(result.expiresAt.getTime()).toEqual(expiresAt.getTime());
+    });
+    
+    test("handles keys with different prefixes", () => {
+      const createdAt = new Date("2023-01-01T12:00:00Z");
+      const expiresAt = new Date("2023-01-01T13:00:00Z");
+      const uuid = "test-uuid";
+      
+      const ext = new S3LockExt();
+      ext.createdAt = createdAt;
+      ext.expiresAt = expiresAt;
+      ext.uuid = uuid;
+      
+      const prefix = "custom/prefix/";
+      const key = `${prefix}${ext.toString()}`;
+      
+      const result = S3LockExt.fromKey(prefix, key);
+      
+      expect(result.uuid).toEqual(uuid);
+      expect(result.createdAt.getTime()).toEqual(createdAt.getTime());
+      expect(result.expiresAt.getTime()).toEqual(expiresAt.getTime());
+    });
+  });
 });

--- a/src/S3LockExt.ts
+++ b/src/S3LockExt.ts
@@ -68,4 +68,9 @@ export class S3LockExt {
 
     return obj;
   }
+
+  static fromKey(prefix: string, key: string): S3LockExt {
+    const end = key.slice(prefix.length);
+    return this.fromString(end);
+  }
 }

--- a/src/acquire.ts
+++ b/src/acquire.ts
@@ -4,6 +4,7 @@ import { S3Lock } from "./S3Lock";
 import { getInputs } from "./inputs";
 import { Timer } from "./timer";
 import * as color from "./color";
+import { Duration } from "./duration";
 
 async function run() {
   try {
@@ -48,9 +49,13 @@ async function run() {
           "already held",
         )} by ${keyDetails}`,
       );
-      core.info(`Waiting until lock expires (${waitDuration} from now)`);
+      
+      // Calculate the minimum wait time between the polling interval and the time until expiry
+      const waitTimeMs = Math.min(timeoutPoll.milliseconds(), waitDuration.milliseconds());
+      const waitTime = Duration.milliseconds(waitTimeMs);
+      core.info(`Waiting ${waitTimeMs}ms before checking again (lock expires in ${waitDuration.milliseconds()}ms)`);
 
-      await timer.sleep(waitDuration);
+      await timer.sleep(waitTime);
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/src/acquire.ts
+++ b/src/acquire.ts
@@ -32,6 +32,7 @@ async function run() {
 
       const key = result.blockingKey;
       const keyDetails = await s3Lock.objectKeyDetails(key);
+      const waitDuration = await s3Lock.waitDuration(key);
 
       if (timer.expired()) {
         core.error(
@@ -47,9 +48,9 @@ async function run() {
           "already held",
         )} by ${keyDetails}`,
       );
-      core.info(`Waiting ${timeoutPoll}`);
+      core.info(`Waiting until lock expires (${waitDuration} from now)`);
 
-      await timer.sleep(timeoutPoll);
+      await timer.sleep(waitDuration);
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,10 +2143,15 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@*, ansi-styles@^6.2.1:
+ansi-styles@*:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+
+ansi-styles@5.2.0, ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2161,11 +2166,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-ansi-styles@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
-  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^3.0.3:
   version "3.1.2"


### PR DESCRIPTION
This PR optimizes the lock waiting behavior by using the exact expiry time of the blocking lock instead of a fixed polling interval. This reduces unnecessary S3 API calls and minimizes the delay between when a lock expires and when we attempt to acquire it.