### PR TITLE
fix: use node24 in sub-actions as well

### DIFF
--- a/acquire/action.yml
+++ b/acquire/action.yml
@@ -35,5 +35,5 @@ outputs:
   acquired-at:
     description: "Timestamp the lock was acquired"
 runs:
-  using: "node20"
+  using: "node24"
   main: "../dist/acquire/index.js"

--- a/release/action.yml
+++ b/release/action.yml
@@ -13,5 +13,5 @@ inputs:
 
 outputs: {}
 runs:
-  using: "node20"
+  using: "node24"
   main: "../dist/release/index.js"


### PR DESCRIPTION
We updated `action.yml`, but not `acquire/action.yml` or
`release/action.yaml`. As part of this I renamed the latter for
consistency.
